### PR TITLE
Pr/9.1.1 unicorn cake patch

### DIFF
--- a/generators/app/templates/src/Foundation/Serialization/code/App_Config/Include/Rainbow.config
+++ b/generators/app/templates/src/Foundation/Serialization/code/App_Config/Include/Rainbow.config
@@ -20,8 +20,7 @@
 				reserves 8 characters (and 248 - 8 - 90 = 150). 
 				Default value: 110
 			-->
-			<setting name="Rainbow.SFS.SerializationFolderPathMaxLength" value="110" />
-
+			<setting name="Rainbow.SFS.SerializationFolderPathMaxLength" value="<%= majorVersion == '9.1.1' ? 150 : 110 %>" />
 			<!--  Rainbow MAX ITEM NAME LENGTH BEFORE TRUNCATION
 				Sitecore item names can become so long that they will not fit on the filesystem without hitting the max path length.
 						This setting controls when Rainbow truncates item file names that are extremely long so they will fit on the filesystem.

--- a/generators/app/templates/src/Foundation/Serialization/code/App_Config/Include/Unicorn/Unicorn.config
+++ b/generators/app/templates/src/Foundation/Serialization/code/App_Config/Include/Unicorn/Unicorn.config
@@ -76,7 +76,7 @@
 					<fieldFormatter type="Rainbow.Formatting.FieldFormatters.CheckboxFieldFormatter, Rainbow" />
 				</serializationFormatter>
 
-				<deserializer type="Unicorn.Deserialization.UnicornDeserializer, Unicorn" singleInstance="true" />
+				<deserializer type="Unicorn.Deserialization.UnicornDeserializer, Unicorn" <%- majorVersion == '9.1.1' ? 'ignoreBranchId="true"' : '' %> singleInstance="true" />
 					<deserializerLogger type="Unicorn.Deserialization.DefaultDeserializerLogger, Unicorn" singleInstance="true"/>
 
 				<evaluator type="Unicorn.Evaluators.SerializedAsMasterEvaluator, Unicorn" singleInstance="true"/>
@@ -194,6 +194,16 @@
 				<!-- Expands variables of the format $(layer) or $(module) based on configuration naming conventions. Useful for setting defaults by convention e.g. in abstract configurations -->
 				<processor type="Unicorn.Pipelines.UnicornExpandConfigurationVariables.HelixConventionVariablesReplacer, Unicorn" />
 			</unicornExpandConfigurationVariables>
+
+<% if (majorVersion == '9.1.1') { -%>
+			<owin.cookieAuthentication.validateIdentity>
+				<processor type="Sitecore.Owin.Authentication.Pipelines.CookieAuthentication.ValidateIdentity.ValidateSiteNeutralPaths, Sitecore.Owin.Authentication">
+					<siteNeutralPaths hint="list">
+						<path hint="unicorn">/unicorn.aspx</path>
+					</siteNeutralPaths>
+				</processor>
+			</owin.cookieAuthentication.validateIdentity>
+<% } -%>
 		</pipelines>
 
 		<processors>

--- a/generators/app/templates/src/build.cake
+++ b/generators/app/templates/src/build.cake
@@ -18,7 +18,7 @@ Sitecore.Parameters.InitParams(
     context: Context,
     msBuildToolVersion: MSBuildToolVersion.Default,
     solutionName: "<%= solutionX %>",
-    scSiteUrl: "https://sc9.local", // default URL exposed from the box
+    scSiteUrl: "http://sc9.local", // default URL exposed from the box
     unicornSerializationRoot: "unicorn-<%= solutionUriX %>"
 );
 
@@ -51,7 +51,6 @@ Task("003-Tests")
 Task("004-Packages")
     .IsDependentOn(Sitecore.Tasks.CopyShipFilesTaskName)
     .IsDependentOn(Sitecore.Tasks.CopySpeRemotingFilesTaskName)
-    .IsDependentOn(Sitecore.Tasks.PrepareWebConfigTask)
     .IsDependentOn(Sitecore.Tasks.RunPackagesInstallationTask)
     ;
 
@@ -73,7 +72,9 @@ Task("Default") // LocalDev
     .IsDependentOn("000-Clean")
     .IsDependentOn("001-Restore")
     .IsDependentOn("002-Build")
-    .IsDependentOn("003-Tests")
+<% if (majorVersion != '9.1.1') { -%>
+     .IsDependentOn("003-Tests")
+<% } -%>
     .IsDependentOn("004-Packages")
     .IsDependentOn("005-Publish")
     .IsDependentOn("006-Sync-Content");


### PR DESCRIPTION
- Fixed unicorn physical paths limits / additional 9.1.1 params
- Fixed unicorn auth settings (added to neutralUrls)
- Excluded Tests step from cake for 9.1.1 (until issue with FakeDB will be resolved)
- Removed PrepareWebConfigTask from cake